### PR TITLE
ci: adjust zizmor advanced security handling

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,6 @@ permissions: {}
 jobs:
   zizmor:
     name: Check GitHub Actions security
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,4 +27,5 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          advanced-security: true
+          advanced-security: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          min-severity: low


### PR DESCRIPTION
## What changed

- Run `zizmor-action` with `advanced-security: false` for non-`push` events, including pull requests and merge queue runs.
- Keep Advanced Security/SARIF uploads enabled on `push` events.
- Set `min-severity: low` for the zizmor scan.

## Why

Fork pull requests cannot upload code scanning results to GitHub Advanced Security, so requiring zizmor code scanning results blocks community PRs. This keeps the check usable for fork PRs while preserving SARIF upload on trusted pushes.

## Validation

- YAML parse check for `.github/workflows/zizmor.yml`
- `git diff --check -- .github/workflows/zizmor.yml`
